### PR TITLE
Change title kwarg of Embed.add_field to name

### DIFF
--- a/docs/getting-started/more-features.mdx
+++ b/docs/getting-started/more-features.mdx
@@ -126,11 +126,11 @@ async def hello(ctx):
         description="Embeds are super easy, barely an inconvenience.",
         color=discord.Colour.blurple(), # Pycord provides a class with default colors you can choose from
     )
-    embed.add_field(title="A Normal Field", value="A really nice field with some information. **The description as well as the fields support markdown!**")
+    embed.add_field(name="A Normal Field", value="A really nice field with some information. **The description as well as the fields support markdown!**")
 
-    embed.add_field(title="Inline Field 1", value="Inline Field 1", inline=True)
-    embed.add_field(title="Inline Field 2", value="Inline Field 2", inline=True)
-    embed.add_field(title="Inline Field 3", value="Inline Field 3", inline=True)
+    embed.add_field(name="Inline Field 1", value="Inline Field 1", inline=True)
+    embed.add_field(name="Inline Field 2", value="Inline Field 2", inline=True)
+    embed.add_field(name="Inline Field 3", value="Inline Field 3", inline=True)
  
     embed.set_footer(text="Footer! No markdown here.") # footers can have icons too
     embed.set_author(name="Pycord Team", icon="https://example.com/link-to-my-image.png")


### PR DESCRIPTION
Hello, new to pycord and noticed while reading the guide that in discord.Embed.add_field, ``title`` is not a valid kwarg, instead it is ``name``.

Hope my changes are valid.

Thank you.