### PR TITLE
Added setup function to cog

### DIFF
--- a/docs/extensions/bridge/index.mdx
+++ b/docs/extensions/bridge/index.mdx
@@ -84,6 +84,9 @@ class Greetings(commands.Cog):
     @bridge.bridge_command()
     async def bye(self, ctx):
         await ctx.respond("Bye!")
+        
+def setup(bot):
+    bot.add_cog(Greetings(bot))
 ```
 
 The cog will automatically split the Bridge Command into their Slash Command and Prefixed Command counterparts.


### PR DESCRIPTION
This pull request adds the setup function in the example to prevent inexperienced users from thinking that with discord.ext.bridge the setup function is unnecessary.