### PR TITLE
refactor: move cogs guide

### DIFF
--- a/docs/extensions/commands/groups.mdx
+++ b/docs/extensions/commands/groups.mdx
@@ -51,6 +51,6 @@ groups!
 :::info Related Topics
 
 -   [Prefixed Commands](./prefixed-commands.mdx)
--   [Cogs](./cogs.mdx)
+-   [Cogs](../../popular-topics/cogs)
 
 :::

--- a/docs/extensions/commands/help-command.mdx
+++ b/docs/extensions/commands/help-command.mdx
@@ -472,7 +472,7 @@ Thanks to InterStella0 for making this guide amazing.
 :::info Related Topics
 
 -   [Subclassing Bots](../../Popular-Topics/subclassing-bots)
--   [Prefixed Commands](prefixed-commands)
--   [Cogs](cogs)
+-   [Prefixed Commands](./prefixed-commands)
+-   [Cogs](../../popular-topics/cogs)
 
 :::

--- a/docs/getting-started/creating-your-first-bot.mdx
+++ b/docs/getting-started/creating-your-first-bot.mdx
@@ -241,10 +241,10 @@ to learn more about prefixed commands.
 
 ### How do I setup modules/cogs?
 
-[Cogs](../extensions/commands/cogs.mdx) are a great way to organize your commands by putting them into
+[Cogs](../popular-topics/cogs) are a great way to organize your commands by putting them into
 groups called cogs. Cogs are separate files that your bot loads to get the commands inside.
 You can read more about cogs, as well as learn how to use them and their benefits, 
-[here](../extensions/commands/cogs.mdx).
+[here](../popular-topics/cogs).
 
 ### How do I add components, such as buttons and dropdown menus, to my bot?
 

--- a/docs/interactions/application-commands/slash-commands.mdx
+++ b/docs/interactions/application-commands/slash-commands.mdx
@@ -135,51 +135,6 @@ bot.add_application_command(math)
 
 The command created above can be invoked by typing `/math advanced square_root`.
 
-## Slash Commands in Cogs
-
-As seen with the [commands extension](../../extensions/commands/cogs), cogs are a useful feature to group commands together. Fortunately, cogs can also work with Slash Commands!
-
-In order to use Slash Commands with cogs, you'll have to use the `slash_command` decorator instead of the `bot.command` decorator. This is imported with the `discord` module, so you don't have to import anything else.
-
-Here's a cog with slash commands instead of prefix commands.
-
-```python title="./cogs/greetings.py"
-import discord
-from discord.ext import commands
-
-class Greetings(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
-    @discord.slash_command()
-    async def hello(self, ctx):
-        await ctx.respond("Hello, this is a slash command from a cog!")
-
-    @discord.slash_command()
-    async def bye(self, ctx):
-        await ctx.respond("Bye, remember that this is a slash command from a cog!")
-
-    @discord.slash_command(guild_ids=[...])
-    async def restricted(self, ctx):
-        await ctx.respond("Hi, this is a restricted slash command from a cog!")
-
-def setup(bot):
-    bot.add_cog(Greetings(bot))
-```
-
-The registered slash commands from the cog should be displayed as normal in the Slash Command menu.
-
-<DiscordComponent>
-  <DiscordMessage profile="robocord">
-    <div slot="interactions">
-      <DiscordInteraction profile="bob" command>
-        hello
-      </DiscordInteraction>
-    </div>
-    Hello, this is a slash command from a cog!
-  </DiscordMessage>
-</DiscordComponent>
-
 ## Options & Option Types
 
 Whenever you're using Slash Commands, you might notice that you can specify parameters that the user has to set or can optionally set. These are called Options.
@@ -258,5 +213,6 @@ bot.run("TOKEN")
 
 -   [Interactions Index](../../interactions)
 -   [Rules and Common Practices](../../getting-started/rules-and-common-practices)
+-   [Cogs](../../popular-topics/cogs)
 
 :::

--- a/docs/popular-topics/cogs.mdx
+++ b/docs/popular-topics/cogs.mdx
@@ -33,6 +33,18 @@ class Greetings(commands.Cog): # create a class for our cog that inherits from c
     async def goodbye(self, ctx):
         await ctx.send('Goodbye!')
 
+    @discord.slash_command() # we can also add application commands
+    async def hello(self, ctx):
+        await ctx.respond('Hello!')
+
+    @discord.slash_command()
+    async def goodbye(self, ctx):
+        await ctx.respond('Goodbye!')
+
+    @discord.user_command()
+    async def greet(self, ctx, member: discord.Member):
+        await ctx.respond(f'{ctx.author.mention} says hello to {member.mention}!')
+
     @commands.Cog.listener() # we can add event listeners to our cog
     async def on_member_join(self, member): # this is called when a member joins the server
     # you must enable the proper intents
@@ -89,9 +101,12 @@ wouldn't be able to access our bot instance.
 
 ### Creating Commands
 
-When creating commands, your decorator would usually be something like `@bot.command()`. If you're using
+When creating prefixed commands, your decorator would usually be something like `@bot.command()`. If you're using
 cogs, this isn't the case. In a cog, you can't access the bot instance outside of functions, so to 
 register a function as a command, you must instead use `@commands.command()`.
+
+Similar to prefixed commands, you'll have to use either the `@discord.slash_command()`, `@discord.user_command()`,
+or `@discord.message_command()` decorators for Application Commands.
 
 Also, when creating a command, make sure that it is indented. If we want a command to be actually
 inside of a cog, it has to be inside of your cog's class. If the command is not inside of the cog,
@@ -104,13 +119,13 @@ access the `bot` variable outside of a function. To make an event, you have to u
 method, `@commands.Cog.listener()`. Events also need `self` as their first parameter.
 
 And that's it! Cogs are a simple and easy way of organizing your code. Now you can check out how to
-create a help command [here](./help-command.mdx)
+create a help command [here](../extensions/commands/help-command).
 
 :::info Related Topics
 
--   [Slash commands in Cogs](../../interactions/application-commands/slash-commands.mdx#slash-commands-in-cogs)
--   [Creating a Help Command](./help-command.mdx)
--   [Rules and Common Practices](../../getting-started/rules-and-common-practices.mdx)
--   [Prefixed Commands](./prefixed-commands.mdx)
+-   [Creating a Help Command](../extensions/commands/help-command)
+-   [Rules and Common Practices](../getting-started/rules-and-common-practices)
+-   [Prefixed Commands](../extensions/commands/prefixed-commands)
+-   [Application Commands](../interactions#application-commands)
 
 :::


### PR DESCRIPTION
Fixes #75 by moving the cogs guide and including a little more information about Application Commands in a cog.