### PR TITLE
Simplified cog example

### DIFF
--- a/docs/popular-topics/cogs.mdx
+++ b/docs/popular-topics/cogs.mdx
@@ -29,15 +29,7 @@ class Greetings(commands.Cog): # create a class for our cog that inherits from c
     async def hello(self, ctx): # all methods now must have both self and ctx parameters
         await ctx.send('Hello!')
 
-    @commands.command()
-    async def goodbye(self, ctx):
-        await ctx.send('Goodbye!')
-
     @discord.slash_command() # we can also add application commands
-    async def hello(self, ctx):
-        await ctx.respond('Hello!')
-
-    @discord.slash_command()
     async def goodbye(self, ctx):
         await ctx.respond('Goodbye!')
 


### PR DESCRIPTION
A few parts of the code example for the "Getting Started" section of the cogs documentation have been removed due to the following reasons:

- The previous code example used the same method name for the command and the application command, causing it to override the original command. This has caused confusion to me previously about why a cog wasn't working as I expected, and it's the main reason for me to submit this PR.
- Having two identical examples of how to define a command and an application command seems redundant. There's no difference between the `hello` and `goodbye` methods, besides the message that the bot responds with.