### PR TITLE
fix(subclassing-bots.mdx): clarify commands example

### DIFF
--- a/docs/popular-topics/subclassing-bots.mdx
+++ b/docs/popular-topics/subclassing-bots.mdx
@@ -37,13 +37,15 @@ Some developers may need to run multiple instances of their bot (perhaps on diff
 ```python title="./alpha_bot.py"
 from src import Bot
 
-
-class AlphaBot(Bot): # subclasses Bot
-    @slash_command() # adds a new slash command on this class
-    async def alpha_feature(self, ctx):
-        await ctx.respond("Alpha Feature!")
+class AlphaBot(Bot):  # subclasses Bot
+    ...  # insert any custom configuration
 
 bot = AlphaBot()
+
+@bot.slash_command()  # adds a new slash command on this class
+async def alpha_feature(ctx):
+    await ctx.respond("Alpha Feature!")
+
 bot.run("TOKEN")
 ```
 

--- a/docs/popular-topics/subclassing-bots.mdx
+++ b/docs/popular-topics/subclassing-bots.mdx
@@ -42,7 +42,7 @@ class AlphaBot(Bot):  # subclasses Bot
 
 bot = AlphaBot()
 
-@bot.slash_command()  # adds a new slash command on this class
+@bot.slash_command()  # adds a new slash command to this subclassed bot
 async def alpha_feature(ctx):
     await ctx.respond("Alpha Feature!")
 


### PR DESCRIPTION
Clarify example which led to [pycord#1513](https://github.com/Pycord-Development/pycord/issues/1513) and [pycord#1479](https://github.com/Pycord-Development/pycord/issues/1479)