### PR TITLE
Correct per-cog error handling example

### DIFF
--- a/docs/popular-topics/error-handling.mdx
+++ b/docs/popular-topics/error-handling.mdx
@@ -195,8 +195,7 @@ class DM(commands.Cog):
         embed.set_image(url=ctx.author.display_avatar.url)
         await ctx.send(embed=embed, reference=ctx.message)
 
-    @commands.Cog.listener()
-    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError):
+    async def cog_command_error(self, ctx: commands.Context, error: commands.CommandError):
         if isinstance(error, commands.PrivateMessageOnly):
             await ctx.send("Sorry, you can only use this in private messages!", reference=ctx.message)
         else:


### PR DESCRIPTION
In the [per-cog error handling](https://guide.pycord.dev/popular-topics/error-handling/#per-cog-handling) section, the guide uses a `Cog.listener` with `on_command_error`. However this is misleading, as listeners are registered globally and as such will catch all command errors on the bot. This has been corrected to use [`cog_command_error`](https://docs.pycord.dev/en/master/api.html#discord.Cog.cog_command_error).