### PR TITLE
Remove debug_guilds mentions

### DIFF
--- a/docs/getting-started/creating-your-first-bot.mdx
+++ b/docs/getting-started/creating-your-first-bot.mdx
@@ -124,7 +124,7 @@ import os # default module
 from dotenv import load_dotenv
 
 load_dotenv() # load all the variables from the env file
-bot = discord.Bot(debug_guilds=[...])
+bot = discord.Bot()
 
 @bot.event
 async def on_ready():
@@ -166,15 +166,23 @@ is a module that we will use to load the env file. You installed this with `pip 
 Next, we load the env file with `load_dotenv()`.
 
 ```py
-bot = discord.Bot(debug_guilds=[...])
+bot = discord.Bot()
 ```
 
 In this line, we create a new instance of [`discord.Bot`](https://docs.pycord.dev/en/master/api.html#discord.Bot).
-In this object, we pass a `debug_guilds` argument, which is a list of guild IDs that the bot's application
-commands will appear in. This is beneficial for testing purposes when we are testing a new command
-or two and don't want everyone to be able to use it. If debug guilds are not specified, all of the 
-servers the bot is in will have access to your slash commands.
+In this object, we can pass various parameters for configuration purposes, such as `owner_ids`
+and [`intents`](https://docs.pycord.dev/en/stable/api.html?highlight=get_message#discord.Intents).
 
+:::caution
+
+Considering that Discord no longer takes 1 hour to update Slash Commands,
+we do not recommend passing `debug_guilds` as parameter because
+it will prevent any global Slash Command to be registered. Instead,
+set [`guild_ids`](https://docs.pycord.dev/en/stable/api.html?highlight=get_message#discord.SlashCommand.guild_ids)
+for the [Application Command](https://docs.pycord.dev/en/stable/api.html?highlight=get_message#application-commands)
+that you intend to test.
+
+:::
 
 ```py
 @bot.event

--- a/docs/getting-started/creating-your-first-bot.mdx
+++ b/docs/getting-started/creating-your-first-bot.mdx
@@ -173,7 +173,6 @@ In this line, we create a new instance of [`discord.Bot`](https://docs.pycord.de
 In this object, we can pass various parameters for configuration purposes, such as `owner_ids`
 and [`intents`](https://docs.pycord.dev/en/stable/api.html?highlight=get_message#discord.Intents).
 
-:::caution
 
 
 ```py

--- a/docs/getting-started/creating-your-first-bot.mdx
+++ b/docs/getting-started/creating-your-first-bot.mdx
@@ -175,14 +175,6 @@ and [`intents`](https://docs.pycord.dev/en/stable/api.html?highlight=get_message
 
 :::caution
 
-Considering that Discord no longer takes 1 hour to update Slash Commands,
-we do not recommend passing `debug_guilds` as parameter because
-it will prevent any global Slash Command to be registered. Instead,
-set [`guild_ids`](https://docs.pycord.dev/en/stable/api.html?highlight=get_message#discord.SlashCommand.guild_ids)
-for the [Application Command](https://docs.pycord.dev/en/stable/api.html?highlight=get_message#application-commands)
-that you intend to test.
-
-:::
 
 ```py
 @bot.event

--- a/docs/interactions/application-commands/slash-commands.mdx
+++ b/docs/interactions/application-commands/slash-commands.mdx
@@ -33,7 +33,7 @@ Let's create a simple Slash Command.
 ```py
 import discord
 
-bot = discord.Bot(debug_guilds=[...]) # specify the guild IDs in debug_guilds
+bot = discord.Bot()
 
 # we need to limit the guilds for testing purposes
 # so other users wouldn't see the command that we're testing
@@ -62,7 +62,7 @@ Let's go through the code.
 
 First, we import Pycord's `discord` package.
 
-Next, we create a [`discord.Bot`](https://docs.pycord.dev/en/master/api.html#discord.Bot) object and assign it to a variable `bot`. Notice how we pass the parameter [`debug_guilds`](https://docs.pycord.dev/en/master/api.html#discord.Bot.debug_guilds). Global Slash Commands take up to an hour to register, however, if we limit our bot commands to a few specific guilds, we can use them instantly on those guilds. This is useful for testing purposes. Once you have polished up your command and made it all shiny, you can share its shininess with all of the bot's servers by removing this parameter.
+Next, we create a [`discord.Bot`](https://docs.pycord.dev/en/master/api.html#discord.Bot) object and assign it to a variable `bot`.
 
 We then go ahead and use the [`@bot.command`](https://docs.pycord.dev/en/master/api.html#discord.Bot.command) decorator, which registers a new Slash Command. We pass a `description` parameter to give a description to the Slash Command. We can also pass a `name` parameter to change the Slash Command's name. By default, the name of the Slash Command will be the name of the function, in this case, `/ping`.
 
@@ -77,7 +77,7 @@ In order to make a Slash Command group, you can use the `bot.create_group` funct
 ```python
 import discord
 
-bot = discord.Bot(debug_guilds=[...]) # specify the guild IDs in debug_guilds
+bot = discord.Bot()
 
 # create Slash Command group with bot.create_group
 greetings = bot.create_group("greetings", "Greet people")

--- a/docs/popular-topics/error-handling.mdx
+++ b/docs/popular-topics/error-handling.mdx
@@ -33,7 +33,7 @@ import discord
 intents = discord.Intents.default()
 intents.message_content = True
 
-bot = discord.Bot(debug_guilds=[...], intents=intents)
+bot = discord.Bot(intents=intents)
 
 
 @bot.slash_command(description="Gets some feedback.")
@@ -114,7 +114,7 @@ until [the feature](https://github.com/Pycord-Development/pycord/issues/1388) is
 import discord
 from discord.ext import commands
 
-bot = discord.Bot(debug_guilds=[...], owner_id=...)  # Your Discord user ID goes in owner_id
+bot = discord.Bot(owner_id=...)  # Your Discord user ID goes in owner_id
 
 
 @bot.slash_command(description="A private command...")
@@ -273,7 +273,7 @@ A non-subclassed bot would implement this like so:
 import discord
 from discord.ext import commands
 
-bot = discord.Bot(debug_guilds=[...])
+bot = discord.Bot()
 
 
 @bot.slash_command(description="Get the bot's current latency!")

--- a/docs/voice/playing.mdx
+++ b/docs/voice/playing.mdx
@@ -41,7 +41,7 @@ You will now want to connect to your server via a node.
 import discord
 import wavelink
 
-bot = discord.Bot(debug_guilds=[...])
+bot = discord.Bot()
 
 async def connect_nodes():
   """Connect to our Lavalink nodes."""

--- a/docs/voice/receiving.mdx
+++ b/docs/voice/receiving.mdx
@@ -33,7 +33,7 @@ You will now want to create your command for recording.
 ```py title="Record Command Example"
 import discord
 
-bot = discord.Bot(debug_guilds=[...])
+bot = discord.Bot()
 connections = {}
 
 @bot.command()


### PR DESCRIPTION
Removes all mentions of `debug_guilds` except a Caution panel when explaining how to define the bot the first time, where it's being explained why we should not use that attribute.