### PR TITLE
Fix custom Tip example

### DIFF
--- a/docs/more/contributing.mdx
+++ b/docs/more/contributing.mdx
@@ -221,6 +221,12 @@ Some **content** with _markdown_ `syntax`.
 Remember that it's `:::important`, not `::: important` with a space!
 
 :::
+
+:::tip Cool Stuff
+
+You can edit an admonition's title by adding text after the `:::` and name, like this!
+
+:::
 ```
 
 <details>


### PR DESCRIPTION
The example for the custom Tip was missing from the code block but showing in the example below it.