### PR TITLE
Feature Rickaym/discord-ext-i18n plugin

### DIFF
--- a/docs/more/community-resources.mdx
+++ b/docs/more/community-resources.mdx
@@ -6,11 +6,12 @@ This page showcases the amazing things created by the Pycord community, includin
 
 ## Plugins
 
-| Name            | Type         | GitHub                                                          |
-| --------------- | ------------ | --------------------------------------------------------------- |
-| Music Cord      | Music        | [NixonXC/cord-music](https://github.com/NixonXC/cord-music)     |
-| pycord-i18n     | Localization | [Dorukyum-pycord-i18n](https://github.com/Dorukyum/pycord-i18n) |
-| pycord-multicog | Cogs         | [pycord-multicog](https://github.com/Dorukyum/pycord-multicog)  |
+| Name             | Type         | GitHub                                                                  |
+| ---------------- | ------------ | ----------------------------------------------------------------------- |
+| Music Cord       | Music        | [NixonXC/cord-music](https://github.com/NixonXC/cord-music)             |
+| pycord-i18n      | Localization | [Dorukyum-pycord-i18n](https://github.com/Dorukyum/pycord-i18n)         |
+| pycord-multicog  | Cogs         | [pycord-multicog](https://github.com/Dorukyum/pycord-multicog)          |
+| discord-ext-i18n | Localization | [Rickaym/discord-ext-i18n](https://github.com/Rickaym/discord-ext-i18n) |
 
 ## Bots
 


### PR DESCRIPTION
Featuring Rickaym/discord-ext-i18n is a localization plugin that with minimal code change does automatic translation for text-content objects (msg, embeds, modals...) into any registered language depending on the preferences of the destination channel or guild.