### PR TITLE
Updating developer portal layout in getting started guide

### DIFF
--- a/docs/getting-started/creating-your-first-bot.mdx
+++ b/docs/getting-started/creating-your-first-bot.mdx
@@ -25,15 +25,16 @@ you should:
     on <button class="blurplebutton">New Application</button>.
 2.  Give your bot a name, and click <button class="blurplebutton">Create</button>.
 3.  Now, you should see a page like this.
-    ![image](https://gblobscdn.gitbook.com/assets%2F-MjPk-Yu4sOq8KGrr_yG%2F-MjdW3OQnwUhacopqSWw%2F-Mjd_-mxrJCrzmaXrAg8%2Fimage.png?alt=media&token=b8e2ae6c-2290-4d37-ad7c-eb412f3fb00e)
+    ![image](https://i.imgur.com/ToAklrb.png)
 4.  Click on the <button class="greybutton">Bot</button> tab on the left side of the screen.
 5.  Click on <button class="blurplebutton">Add bot</button>.
 6.  You can give it a name, change the Avatar, etc.
 
 ## Inviting the bot
 
-Now, lets get the bot added to some servers. Go to the <button class="greybutton">OAuth2</button> tab
-in the left pane and select `bot` and `applications.commands` as scopes.
+Now, lets get the bot added to some servers. Go to the <button class="greybutton">OAuth2</button> tab,
+select the <button class="greybutton">URL Generator</button> in the left pane and then select `bot` and
+`applications.commands` as scopes.
 
 You may want your bot to have application commands, which is what the `application.commands` scope
 allows your bot to make.
@@ -50,7 +51,7 @@ Administrator permissions are fine.
 
 :::
 
-![image](https://gblobscdn.gitbook.com/assets%2F-MjPk-Yu4sOq8KGrr_yG%2F-Mk6tNY3LfDkjd6pqdpL%2F-Mk6tkdpddEWoa2jczZk%2Fimage.png?alt=media&token=52c8a29f-a798-48f8-a8c7-4ecca2681f79)
+![image](https://i.imgur.com/86q1MpF.png)
 
 You can use this link to invite the bot.
 
@@ -67,10 +68,11 @@ considered a snowflake. A Discord user ID is also a snowflake.
 Now, lets get your bot's token. To do this, you want to:
 
 1.  Go back to the <button class="greybutton">Bot</button> tab.
-2.  Click on the <button class="blurplebutton">Copy</button> button in the "Token" section.
-    ![image](https://gblobscdn.gitbook.com/assets%2F-MjPk-Yu4sOq8KGrr_yG%2F-MjdbU12JISJorAZxrKH%2F-MjdbpUsapzb5n15Po5P%2Fimage.png?alt=media&token=118e259f-940a-4f6c-b3a3-c29f3a54100d)
+2.  Click on the <button class="blurplebutton">Reset Token</button> button in the "Token" section.
+    ![image](https://i.imgur.com/zyk0W4E.png)
 
-Now, you have your bot's token copied to your clipboard.
+Now, copy your bot's token to your clipbaord. Keep note of this, as it is only visible once: if you
+lose it, you will have to regenerate it!
 
 :::danger
 

--- a/docs/getting-started/creating-your-first-bot.mdx
+++ b/docs/getting-started/creating-your-first-bot.mdx
@@ -33,7 +33,7 @@ you should:
 ## Inviting the bot
 
 Now, lets get the bot added to some servers. Go to the <button class="greybutton">OAuth2</button> tab,
-select the <button class="greybutton">URL Generator</button> in the left pane and then select `bot` and
+select <button class="greybutton">URL Generator</button> in the dropdown list and then select `bot` and
 `applications.commands` as scopes.
 
 You may want your bot to have application commands, which is what the `application.commands` scope


### PR DESCRIPTION
The Discord Developer Portal layout has changed since the "Getting Started - Creating Your First Bot" page was published (https://guide.pycord.dev/getting-started/creating-your-first-bot). I've updated it to explain some of the design changes so people don't get confused, such as by now having to click "Oauth2 --> URL Generator" to get an invite URL, and having to "Reset Token" to get your bot token, rather than just copying the pre-existing one again.

I've used Imgur image URLs for the updated screenshots, however, I notice you use gitbook for your media, so feel free to upload my screenshots to that and replace the Imgur URLs with gitbook.