### PR TITLE
Add intents for prefixed commands

### DIFF
--- a/docs/extensions/commands/prefixed-commands.mdx
+++ b/docs/extensions/commands/prefixed-commands.mdx
@@ -186,7 +186,10 @@ import discord
 from discord.ext import commands # Import the commands extension
 # discord.ext.commands are not the same as discord.commands!
 
-bot = commands.Bot(command_prefix="!") # You can change the command prefix to whatever you want.
+intents = discord.Intents.default() #Defining intents
+intents.message_content = True # Adding the message_content intent so that the bot can read user messages
+
+bot = commands.Bot(command_prefix="!", intents=intents) # You can change the command prefix to whatever you want.
 
 @bot.command() # This is the decorator we use to create a prefixed command.
 async def ping(ctx): # This is the function we will use to create the command.

--- a/docs/extensions/commands/prefixed-commands.mdx
+++ b/docs/extensions/commands/prefixed-commands.mdx
@@ -91,7 +91,10 @@ async def on_message(message):
 import discord
 from discord.ext import commands
 
-bot = commands.Bot(command_prefix="!")
+intents = discord.Intents.default()
+intents.message_content = True
+
+bot = commands.Bot(command_prefix="!", intents=True)
 
 @bot.command()
 async def ping(ctx):

--- a/docs/extensions/commands/prefixed-commands.mdx
+++ b/docs/extensions/commands/prefixed-commands.mdx
@@ -94,7 +94,7 @@ from discord.ext import commands
 intents = discord.Intents.default()
 intents.message_content = True
 
-bot = commands.Bot(command_prefix="!", intents=True)
+bot = commands.Bot(command_prefix="!", intents=intents)
 
 @bot.command()
 async def ping(ctx):


### PR DESCRIPTION
Modified the guide to contain intents for prefixed commands. Prefixed commands will not work without the message_content intent.