### PR TITLE
feat(metadata): change embed icon to match main website

### DIFF
--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -18,7 +18,9 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ title, description, child
                 <meta name="description" content={ description } />
                 <meta property="og:description" content="The official guide for making bots and other Discord applications using the Pycord library." />
                 <meta property="og:title" content="The Pycord Guide" />
-                <meta property="og:thumbnail" content="https://guide.pycord.dev/img/logo.png" />
+                <meta property="og:image" content="https://guide.pycord.dev/img/logo.png" />
+                <meta property="og:image:type" content="image/png" />
+                <meta property="og:image:alt" content="Pycord Logo" />
                 <meta name="theme-color" content="#5865F2" />
             </Head>
             <Layout>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -18,7 +18,7 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ title, description, child
                 <meta name="description" content={ description } />
                 <meta property="og:description" content="The official guide for making bots and other Discord applications using the Pycord library." />
                 <meta property="og:title" content="The Pycord Guide" />
-                <meta property="og:image" content="https://guide.pycord.dev/img/logo.png" />
+                <meta property="og:thumbnail" content="https://guide.pycord.dev/img/logo.png" />
                 <meta name="theme-color" content="#5865F2" />
             </Head>
             <Layout>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -16,11 +16,24 @@ const DefaultLayout: React.FC<DefaultLayoutProps> = ({ title, description, child
             <Head>
                 <title>{ title } - { site.tagline }</title>
                 <meta name="description" content={ description } />
+
+                <meta property="og:type" content="website" />
                 <meta property="og:description" content="The official guide for making bots and other Discord applications using the Pycord library." />
                 <meta property="og:title" content="The Pycord Guide" />
                 <meta property="og:image" content="https://guide.pycord.dev/img/logo.png" />
                 <meta property="og:image:type" content="image/png" />
                 <meta property="og:image:alt" content="Pycord Logo" />
+                <meta property="og:site_name" content={ title } />
+                <meta property="og:locale" content="en_US" />
+                <meta property="article:author" content="Pycord Development" />
+
+                <meta name="twitter:card" content="summary" />
+                <meta name="twitter:site" content="@PycordDev" />
+                <meta name="twitter:creator" content="@PycordDev" />
+                <meta name="twitter:title" content={ title } />
+                <meta name="twitter:description" content="The official guide for making bots and other Discord applications using the Pycord library." />
+                <meta name="twitter:image" content={"https://guide.pycord.dev/img/logo.png" } />
+                <meta name="twitter:image:alt" content="Pycord Logo" />
                 <meta name="theme-color" content="#5865F2" />
             </Head>
             <Layout>


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Currently, the embeds for the main website and the guide website are inconsistent.

<img width="497" alt="image" src="https://github.com/Pycord-Development/guide/assets/89910983/ca763128-b10e-4487-9395-7b2eef788583">

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes.
- [x] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
